### PR TITLE
BUILD-3539 Rewrite license-headers CI (without vault.sh)

### DIFF
--- a/.cirrus.star
+++ b/.cirrus.star
@@ -1,4 +1,4 @@
-load("github.com/SonarSource/cirrus-modules@v1", "cirrus_auth")
+load("github.com/SonarSource/cirrus-modules@v2", "load_features")
 
 def main(ctx):
-  return cirrus_auth()
+    return load_features(ctx)

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,10 +1,14 @@
 env:
-  CIRRUS_CLONE_DEPTH: 20
-  ARTIFACTORY_PRIVATE_USERNAME: vault-sonarsource-license-headers-private-reader
-  ARTIFACTORY_DEPLOY_USERNAME: vault-sonarsource-license-headers-qa-deployer
-  #Possible values for ARTIFACTORY_DEPLOY_REPO: sonarsource-private-qa, sonarsource-public-qa
-  ARTIFACTORY_DEPLOY_REPO: sonarsource-public-qa  
-container_definition: &CONTAINER_DEFINITION
+  CIRRUS_CLONE_DEPTH: "20"
+
+  # Use bash (instead of sh on linux or cmd.exe on Windows)
+  CIRRUS_SHELL: bash
+
+  ARTIFACTORY_URL: VAULT[development/kv/data/repox data.url]
+  ARTIFACTORY_PRIVATE_USERNAME: VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-private-reader username]
+  ARTIFACTORY_PRIVATE_PASSWORD: VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-private-reader access_token]
+
+eks_container: &CONTAINER_DEFINITION
   image: ${CIRRUS_AWS_ACCOUNT}.dkr.ecr.eu-central-1.amazonaws.com/base:j11-latest
   cluster_name: ${CIRRUS_CLUSTER_NAME}
   region: eu-central-1
@@ -13,29 +17,34 @@ container_definition: &CONTAINER_DEFINITION
 only_sonarsource_qa: &ONLY_SONARSOURCE_QA
   only_if: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_TAG == "" && ($CIRRUS_PR != "" || $CIRRUS_BRANCH == "master" || $CIRRUS_BRANCH =~ "branch-.*" || $CIRRUS_BRANCH =~ "dogfood-on-.*")
 
-vault: &VAULT
-  vault_script:
-    - vault.sh
-
 build_task:
+  <<: *ONLY_SONARSOURCE_QA
   eks_container:
     <<: *CONTAINER_DEFINITION
     cpu: 2
     memory: 2G
   env:
-    SONAR_HOST_URL: https://next.sonarqube.com/sonarqube
+    # possible values for ARTIFACTORY_DEPLOY_REPO: sonarsource-private-qa, sonarsource-public-qa
+    ARTIFACTORY_DEPLOY_REPO: sonarsource-public-qa
+    ARTIFACTORY_DEPLOY_USERNAME: VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-qa-deployer username]
+    ARTIFACTORY_DEPLOY_PASSWORD: VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-qa-deployer access_token]
     #allow deployment of pull request artifacts to repox
-    DEPLOY_PULL_REQUEST: true
+    DEPLOY_PULL_REQUEST: "true"
+    
+    # analysis on sonarcloud
+    SONAR_HOST_URL: VAULT[development/kv/data/sonarcloud data.url]
+    SONAR_TOKEN: VAULT[development/kv/data/sonarcloud data.token]
+
+    SIGN_KEY: VAULT[development/kv/data/sign data.key]
+    PGP_PASSPHRASE: VAULT[development/kv/data/sign data.passphrase]
+
   maven_cache:
     folder: ${CIRRUS_WORKING_DIR}/.m2/repository
-  <<: *VAULT
   build_script:
     - source cirrus-env BUILD
-    - source set_maven_build_version $BUILD_NUMBER
-    - mvn deploy -Pdeploy-sonarsource,release -B -e -V
+    - regular_mvn_build_deploy_analyze
   cleanup_before_cache_script: cleanup_maven_repository
 
- 
 promote_task:
   depends_on:
     - build
@@ -45,10 +54,17 @@ promote_task:
     cpu: 0.5
     memory: 500M
   env:
-    #artifacts that will have downloadable links in burgr
+    GITHUB_TOKEN: VAULT[development/github/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-promotion token]
+    # promotion cloud function
+    GCF_ACCESS_TOKEN: VAULT[development/kv/data/promote data.token]
+    PROMOTE_URL: VAULT[development/kv/data/promote data.url]
+    # artifacts that will have downloadable links in burgr
     ARTIFACTS: org.sonarsource.license-headers:license-headers:jar
+    BURGR_URL: VAULT[development/kv/data/burgr data.url]
+    BURGR_USERNAME: VAULT[development/kv/data/burgr data.cirrus_username]
+    BURGR_PASSWORD: VAULT[development/kv/data/burgr data.cirrus_password]
   maven_cache:
     folder: ${CIRRUS_WORKING_DIR}/.m2/repository
-  <<: *VAULT
-  script: cirrus_promote_maven
+  script:
+    - cirrus_promote_maven
   cleanup_before_cache_script: cleanup_maven_repository

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.sonarsource.parent</groupId>
     <artifactId>parent</artifactId>
-    <version>59.0.29</version>
+    <version>68.0.0.247</version>
   </parent>
   <groupId>org.sonarsource.license-headers</groupId>
   <artifactId>license-headers</artifactId>
@@ -11,21 +11,22 @@
   <packaging>jar</packaging>
   <name>SonarSource :: License Headers</name>
   <description>Templates of source file headers for SonarSource projects. Used by parent pom.</description>
-  <url>http://www.sonarsource.com</url>
+  <url>https://www.sonarsource.com</url>
 
   <properties>
     <gitRepositoryName>license-headers</gitRepositoryName>
+    <sonar.organization>sonarsource</sonar.organization>
   </properties>
   
   <organization>
     <name>SonarSource</name>
-    <url>http://www.sonarsource.com</url>
+    <url>https://www.sonarsource.com</url>
   </organization>
 
   <licenses>
     <license>
       <name>GNU LGPL 3</name>
-      <url>http://www.gnu.org/licenses/lgpl.txt</url>
+      <url>https://www.gnu.org/licenses/lgpl.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>


### PR DESCRIPTION
# BUILD-3539 Rewrite license-headers CI (without vault.sh)

## Changes
* use cirrus-modules@v2 and adapt the CI to follow the standardized way used across the company
* fix sonar analysis (never worked before)
* code gardening (http -> https etc)

## Depends on

* https://github.com/SonarSource/re-terraform-aws-vault/pull/731