### PR TITLE
BUILD-9625 Updates license headers to SonarSource Sàrl

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 SonarSource :: License Headers
-Copyright (C) 2008-2017 SonarSource SA
+Copyright (C) 2008-2025 SonarSource Sàrl
 mailto:info AT sonarsource DOT com
 
 This product includes software developed at

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ### License
 
-Copyright 2008-2024 SonarSource.
+Copyright 2008-2024 SonarSource Sàrl.
 
 Licensed under the [GNU Lesser General Public License, Version 3.0](http://www.gnu.org/licenses/lgpl.txt)

--- a/src/main/resources/sonarsource/licenseheaders/SSALv1.txt
+++ b/src/main/resources/sonarsource/licenseheaders/SSALv1.txt
@@ -3,7 +3,7 @@ Copyright (C) ${license.years} ${license.owner}
 ${license.mailto}
 
 This program is free software; you can redistribute it and/or
-modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
 
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of


### PR DESCRIPTION
This pull request updates copyright and licensing information to reflect the correct legal entity name, changing references from "SonarSource SA" to "SonarSource Sàrl" across several documentation and license files.

Legal entity name updates:

* [`NOTICE.txt`](diffhunk://#diff-b810ebe4ffda4293c79d292059b45b59de7e649e86314ffd5a1ee4eb4b1e08c8L2-R2): Changed the copyright holder from "SonarSource SA" to "SonarSource Sàrl" and updated the copyright year to 2025.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3): Updated the copyright attribution from "SonarSource" to "SonarSource Sàrl".
* [`src/main/resources/sonarsource/licenseheaders/SSALv1.txt`](diffhunk://#diff-57721893d554d2efba1db49602e224e740c5c61b5efe6336d98feb364e4ccb7dL6-R6): Updated the license terms to reference "SonarSource Sàrl" instead of "SonarSource SA".