### PR TITLE
BUILD-10085  remove year from template SonarSource.txt

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,3 +40,5 @@ jobs:
       contents: write
     steps:
       - uses: SonarSource/ci-github-actions/promote@master # dogfood
+        with:
+          promote-pull-request: true

--- a/src/main/resources/sonarsource/licenseheaders/SonarSource.txt
+++ b/src/main/resources/sonarsource/licenseheaders/SonarSource.txt
@@ -1,3 +1,3 @@
-Copyright (C) ${license.owner}
+Copyright (C) * ${license.owner}
 All rights reserved
 ${license.mailto}

--- a/src/main/resources/sonarsource/licenseheaders/SonarSource.txt
+++ b/src/main/resources/sonarsource/licenseheaders/SonarSource.txt
@@ -1,3 +1,3 @@
-Copyright (C) ${license.years} ${license.owner}
+Copyright (C) ${license.owner}
 All rights reserved
 ${license.mailto}


### PR DESCRIPTION
This pull request includes minor updates to the CI workflow and the license header template.

*CI/CD workflow update:*
* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R43-R44): Enabled the promotion of pull requests in the SonarSource GitHub Actions workflow by setting `promote-pull-request: true`.

*License header template update:*
* [`src/main/resources/sonarsource/licenseheaders/SonarSource.txt`](diffhunk://#diff-c4adfff577170e25a80b48b35aed40f677171d821371f40aedba9579997b36e3L1-R1): Removed the `${license.years}` variable from the copyright line, simplifying the template.