### PR TITLE
BUILD-10792 Remove copyright years from license header templates

### DIFF
--- a/src/main/resources/sonarsource/licenseheaders/AL2.txt
+++ b/src/main/resources/sonarsource/licenseheaders/AL2.txt
@@ -1,5 +1,5 @@
 ${license.title}
-Copyright (c) ${license.years} ${license.owner}
+Copyright (C) ${license.owner}
 ${license.mailto}
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/resources/sonarsource/licenseheaders/GNU LGPL v3.txt
+++ b/src/main/resources/sonarsource/licenseheaders/GNU LGPL v3.txt
@@ -1,5 +1,5 @@
 ${license.title}
-Copyright (C) ${license.years} ${license.owner}
+Copyright (C) ${license.owner}
 ${license.mailto}
 
 This program is free software; you can redistribute it and/or

--- a/src/main/resources/sonarsource/licenseheaders/MIT.txt
+++ b/src/main/resources/sonarsource/licenseheaders/MIT.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) ${license.years} ${license.owner}
+Copyright (c) ${license.owner}
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/sonarsource/licenseheaders/MIT.txt
+++ b/src/main/resources/sonarsource/licenseheaders/MIT.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) ${license.owner}
+Copyright (C) ${license.owner}
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/sonarsource/licenseheaders/SSALv1.txt
+++ b/src/main/resources/sonarsource/licenseheaders/SSALv1.txt
@@ -2,8 +2,8 @@ ${license.title}
 Copyright (C) ${license.owner}
 ${license.mailto}
 
-You can redistribute and/or modify this program under the terms of the 
-Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+You can redistribute and/or modify this program under the terms of
+the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
 
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/resources/sonarsource/licenseheaders/SSALv1.txt
+++ b/src/main/resources/sonarsource/licenseheaders/SSALv1.txt
@@ -7,7 +7,7 @@ the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
 
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 See the Sonar Source-Available License for more details.
 
 You should have received a copy of the Sonar Source-Available License

--- a/src/main/resources/sonarsource/licenseheaders/SSALv1.txt
+++ b/src/main/resources/sonarsource/licenseheaders/SSALv1.txt
@@ -1,9 +1,9 @@
 ${license.title}
-Copyright (C) ${license.years} ${license.owner}
+Copyright (C) ${license.owner}
 ${license.mailto}
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+You can redistribute and/or modify this program under the terms of the 
+Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
 
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/main/resources/sonarsource/licenseheaders/SonarSource.txt
+++ b/src/main/resources/sonarsource/licenseheaders/SonarSource.txt
@@ -1,3 +1,3 @@
-Copyright (C) ${license.years} ${license.owner}
-All rights reserved
+Copyright (C) ${license.owner}
+For more information, see https://sonarsource.com/legal/
 ${license.mailto}


### PR DESCRIPTION
BUILD-10792 Remove copyright years from license header templates

## Context
Part of [BUILD-10792](https://sonarsource.atlassian.net/browse/BUILD-10792): dateless license headers so parent POMs can drop `license.years` and relax year checking in Mycila license-maven-plugin.

## Changes
- Remove `${license.years}` from **MIT**, **AL2**, **GNU LGPL v3**, **SSALv1**, and **SonarSource** templates under `src/main/resources/sonarsource/licenseheaders/`.
- **SSALv1**: wording aligned with the updated SSAL notice (redistribute/modify sentence).
- **SonarSource**: replace static "All rights reserved" line with link to https://sonarsource.com/legal/
- **AL2**: copyright line uses `(C)` and owner only (matches bundled artifact).

## Breaking / follow-up
Consumers must refresh file headers (e.g. `mvn license:format`) and bump `license-headers` in parent POMs after release. Parent `parent-oss` / `parent` still need separate changes to remove year properties and plugin year checks.

## Related
- Repo: https://github.com/SonarSource/license-headers

[BUILD-10792]: https://sonarsource.atlassian.net/browse/BUILD-10792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ