### PR TITLE
BUILD-10765 Important: Update SonarSource/gh-action_release to 6.5.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@7b055eca5ce771ff254fbec2697c0fc1c7207e1e # 6.4.0
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@c52861bb0e5dd564187f3fd74e048f20aef0f761 # 6.5.0
     with:
       publishToBinaries: false
       mavenCentralSync: true


### PR DESCRIPTION
**Important:** Update `SonarSource/gh-action_release` to `c52861bb0e5dd564187f3fd74e048f20aef0f761` (6.5.0) for compliance with allowed versions.

See: https://discuss.sonarsource.com/t/action-required-update-your-github-actions-cache-release-and-releasability-before-10-04/23899/5