### PR TITLE
BUILD-10765 Important: Update SonarSource/gh-action_release to v6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@c52861bb0e5dd564187f3fd74e048f20aef0f761 # 6.5.0
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v6
     with:
       publishToBinaries: false
       mavenCentralSync: true


### PR DESCRIPTION
**Important:** Update GitHub Actions to compliant versions.

- `.github/workflows/release.yml`: `release` `c52861bb0e5dd564187f3fd74e048f20aef0f761` → `v6`

See: https://discuss.sonarsource.com/t/action-required-update-your-github-actions-cache-release-and-releasability-before-31-04-2026/23899