### PR TITLE
BUILD-11249 Upgrade GitHub Actions workflow dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>SonarSource/renovate-config:dev-infra-squad"
+  ]
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,8 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: SonarSource/ci-github-actions/build-maven@master
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: SonarSource/ci-github-actions/build-maven@v1
         with:
           deploy-pull-request: true
           artifactory-reader-role: private-reader
@@ -39,4 +39,4 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - uses: SonarSource/ci-github-actions/promote@master # dogfood
+      - uses: SonarSource/ci-github-actions/promote@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,22 @@
 ---
 name: sonar-release
-# This workflow is triggered when publishing a new github release
 # yamllint disable-line rule:truthy
 on:
-  release:
-    types:
-      - published
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version'
+        required: true
+        type: string
 
 jobs:
   release:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v6
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v7
     with:
+      version: ${{ inputs.version }}
       publishToBinaries: false
       mavenCentralSync: true
-      slackChannel: team-release-engineering-notifs
+      slackChannel: squad-eng-xp-notifications


### PR DESCRIPTION
## Summary

- `ci-github-actions/build-maven` and `ci-github-actions/promote`: `@master` → `@v1`
- `gh-action_release/main.yaml`: `@v6` → `@v7` with `workflow_dispatch` trigger (+ required `version` input)
- `actions/checkout`: `v4.2.2` → `v6.0.2` (sha pinned)
- Slack channel: `team-release-engineering-notifs` → `squad-eng-xp-notifications`
